### PR TITLE
Update poeTransactionCounter.js

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -82,6 +82,7 @@ const microtransactions = {
     // Expedition
     "Soulkeeper": 30,
     "Soulkeeper Vizier": 60,
+    "Soulkeepr Vizier": 60, //ggg have misspelled this in the account transactions list
     "Soulkeeper Demigod": 90,
     "Aesir": 30,
     "Aesir Warrior": 60,


### PR DESCRIPTION

![soulkeepr](https://github.com/DanielTaranger/poeTransactionCounter/assets/44515073/a171b6f7-7cc4-4a44-b9ad-bc1bda06c16a)
shimmed the expedition list for Soulkeeper Vizier's misspelling in the account list. I cannot confirm whether all 'Soulkeeper' packs are this way, I only purchased the Vizier version, so I did not modify the others.