### PR TITLE
Add missing pack: Cursed Supporter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Instructions
 To use this script:
 
-1. Login to your pathofexile.com transaction page 
+1. Login to your pathofexile.com [transaction](https://www.pathofexile.com/my-account/transactions) page
 2. Copy the contents from the poeTransactionCounter.js script
 3. Right click your browser and select inspect element.
 4. Get to console and paste it in and hit enter. The browser may require you to type in a safety word to allow to paste scripts.

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -134,6 +134,9 @@ const microtransactions = {
     "Faithsworn": 30,
     "Elite Faithsworn": 60,
 
+    // 2021 Endless Delve / Nexus -- https://www.pathofexile.com/forum/view-thread/3218435
+    "Cursed Supporter Pack": 60,
+
     // 2021 Core
     "Delve Core": 60,
     "Breach Core": 100,


### PR DESCRIPTION
One of my purchased supporter packs was missing. I tracked down the original GGG announcement and cost for the `Cursed Supporter Pack`, $60.