### PR TITLE
Add missing packs to console out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Instructions
 To use this script:
 
-1. Login to your pathofexile.com transaction page 
+1. Login to your pathofexile.com [transaction](https://www.pathofexile.com/my-account/transactions) page
 2. Copy the contents from the poeTransactionCounter.js script
 3. Right click your browser and select inspect element.
 4. Get to console and paste it in and hit enter. The browser may require you to type in a safety word to allow to paste scripts.

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -355,5 +355,6 @@ for (let element of elements) {
 if (errormessage == "") {
     alert(`You have spent \$${total} on microtransactions`);
 } else {
+    console.warn( "The following supporter packs are unaccounted for...", errormessage );
     alert("You have spent " + "$" + total + " on microtransactions \n\n" + "Packs not found: " + errormessage);
 }


### PR DESCRIPTION
I wanted a way to copy-paste the missing supporter packs and the `alert()` modal box wouldn't let me.  Added the missing supporter packs to the console out.  Used `console.warn()` so they would stand out.