### PR TITLE
PoE2 Early Access Supporter Packs

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,6 +1,14 @@
 const elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
 
 const microtransactions = {
+    // PoE2 Early Access
+    "Path of Exile 2 Early Access": 30,
+    "Lord of Ogham": 60,
+    "King of the Faridun": 100,
+    "Thaumaturge of the Vaal": 160,
+    "Warlord of the Karui": 240,
+    "Liberator of Wraeclast": 480,
+
     // Exilecon 2023
     "Exilecon 2023 Ultra VIP": 2000,
     "Exilecon 2023 VIP": 700,


### PR DESCRIPTION
Add PoE2 Early Access Supporter Packs.

This change was tested with the Supporter Packs `Path of Exile 2 Early Access` and `Liberator of Wraeclast`.