### PR TITLE
Add apostrophes to Kalguur names

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -32,8 +32,8 @@ const microtransactions = {
     "Divine Paladin": 60,
     "Sacred Paladin": 90,
     "Penance": 30,
-    "Acolytes Penance": 60,
-    "Zealots Penance": 90,
+    "Acolyte's Penance": 60,
+    "Zealot's Penance": 90,
 
     //Necropolis
     "Solar": 30,


### PR DESCRIPTION
Fixes https://github.com/DanielTaranger/poeTransactionCounter/issues/32


![image](https://github.com/user-attachments/assets/4ecbc9cb-1213-497a-ad29-38a05af8df6b)

It's branded with the apostrophes [on the PoE site](https://www.pathofexile.com/purchase).

![image](https://github.com/user-attachments/assets/9bbc0236-0c9b-4512-825b-81357c9fba77)
