### PR TITLE
implement levenshtein distance to compensate for inconsistent naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ To use this script:
 3. Right click your browser and select inspect element.
 4. Get to console and paste it in and hit enter. The browser may require you to type in a safety word to allow to paste scripts.
 
-If you feel adventurous you can also drag this <a href="javascript:(function()%7Bfunction%20callback()%7Bconsole.log(%22dummy%20log%22)%7Dvar%20s%3Ddocument.createElement(%22script%22)%3Bs.src%3D%22https%3A%2F%2Fcdn.statically.io%2Fgh%2Fpeeteer1245%2FpoeTransactionCounter%2Fmaster%2FpoeTransactionCounter.js%22%3Bif(s.addEventListener)%7Bs.addEventListener(%22load%22%2Ccallback%2Cfalse)%7Delse%20if(s.readyState)%7Bs.onreadystatechange%3Dcallback%7Ddocument.body.appendChild(s)%3B%7D)()">Bookmarklet</a> into your Bookmarks.
+If you feel adventurous you can also save this Bookmarklet into your Bookmarks.
+
+`javascript:(function()%7Bfunction%20callback()%7Bconsole.log(%22dummy%20log%22)%7Dvar%20s%3Ddocument.createElement(%22script%22)%3Bs.src%3D%22https%3A%2F%2Fcdn.statically.io%2Fgh%2Fpeeteer1245%2FpoeTransactionCounter%2Fmaster%2FpoeTransactionCounter.js%22%3Bif(s.addEventListener)%7Bs.addEventListener(%22load%22%2Ccallback%2Cfalse)%7Delse%20if(s.readyState)%7Bs.onreadystatechange%3Dcallback%7Ddocument.body.appendChild(s)%3B%7D)()`
 
 Respective reddit thread:
 https://www.reddit.com/r/pathofexile/comments/6fjm8w/toola_script_i_made_that_shows_how_much_you_spent/?sort=new

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ To use this script:
 
 If you feel adventurous you can also save this Bookmarklet into your Bookmarks.
 
-`javascript:(function()%7Bfunction%20callback()%7Bconsole.log(%22dummy%20log%22)%7Dvar%20s%3Ddocument.createElement(%22script%22)%3Bs.src%3D%22https%3A%2F%2Fcdn.statically.io%2Fgh%2Fpeeteer1245%2FpoeTransactionCounter%2Fmaster%2FpoeTransactionCounter.js%22%3Bif(s.addEventListener)%7Bs.addEventListener(%22load%22%2Ccallback%2Cfalse)%7Delse%20if(s.readyState)%7Bs.onreadystatechange%3Dcallback%7Ddocument.body.appendChild(s)%3B%7D)()`
+```
+javascript:(function()%7Bfunction%20callback()%7Bconsole.log(%22dummy%20log%22)%7Dvar%20s%3Ddocument.createElement(%22script%22)%3Bs.src%3D%22https%3A%2F%2Fcdn.statically.io%2Fgh%2Fpeeteer1245%2FpoeTransactionCounter%2Fmaster%2FpoeTransactionCounter.js%22%3Bif(s.addEventListener)%7Bs.addEventListener(%22load%22%2Ccallback%2Cfalse)%7Delse%20if(s.readyState)%7Bs.onreadystatechange%3Dcallback%7Ddocument.body.appendChild(s)%3B%7D)()
+```
+
+This bookmarklet uses the statically CDN to fetch the current version of the js script and runs it.
 
 Respective reddit thread:
 https://www.reddit.com/r/pathofexile/comments/6fjm8w/toola_script_i_made_that_shows_how_much_you_spent/?sort=new

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Instructions
 To use this script:
 
-1. Login to your pathofexile.com transaction page 
+1. Login to your pathofexile.com [transaction](https://www.pathofexile.com/my-account/transactions) page
 2. Copy the contents from the poeTransactionCounter.js script
 3. Right click your browser and select inspect element.
 4. Get to console and paste it in and hit enter. The browser may require you to type in a safety word to allow to paste scripts.

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -159,8 +159,9 @@ const microtransactions = {
     "Crescent": 30,
     "Silver Crescent": 60,
 
-    // 2021 Endless Delve / Nexus -- https://www.pathofexile.com/forum/view-thread/3218435
-    "Cursed Supporter Pack": 60,
+    // 2021 Endless Delve / Nexus
+    // https://www.pathofexile.com/forum/view-thread/3218435
+    "Cursed": 60,
 
     // Ritual
     "Renegade": 30,
@@ -378,9 +379,6 @@ const microtransactions = {
     // https://www.pathofexile.com/forum/view-thread/1185814
     "Koala": 14,
     "Brazil": 40,
-    // 2021 Endless Delve / Nexus
-    // https://www.pathofexile.com/forum/view-thread/3218435
-    "Cursed": 60,
 }
 
 let total = 0;

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -379,5 +379,6 @@ for (let element of elements) {
 if (errormessage == "") {
     alert(`You have spent \$${total} on microtransactions`);
 } else {
+    console.warn( "The following supporter packs are unaccounted for...", errormessage );
     alert("You have spent " + "$" + total + " on microtransactions \n\n" + "Packs not found: " + errormessage);
 }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -3,6 +3,21 @@ var total = 0;
 var errormessage = "";
 
 var microtransactions = {
+    // 2023 Core
+    "Tormentor": 60,
+    "Hellfire": 100,
+    "Bloodthirsty": 160,
+    "Chronomancer": 240,
+    "Voidborn": 480,
+
+    // The Forbidden Sanctum
+    "Forgekeeper": 30,
+    "Forgeguard": 60,
+    "Forgemaster": 90,
+    "Gemling": 30,
+    "Gemling Artificer": 60,
+    "Gemling Sage": 90,
+
     // Lake of Kalandra
     "Knight": 30,
     "Knightmaster": 60,
@@ -51,8 +66,8 @@ var microtransactions = {
     "Aesir Demigod": 90,
 
     // Ultimatum
-    "Imperial Sun": 60,
     "Sun": 30,
+    "Imperial Sun": 60,
     "Crescent": 30,
     "Silver Crescent": 60,
 
@@ -243,7 +258,6 @@ var microtransactions = {
     "1065 Point": 100,
 
     // Vault Passes
-    "Vault Pass (Kalandra)": 30,
     "Vault Pass": 30,
 
     // Questionmark

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -371,7 +371,7 @@ const microtransactions = {
     "Comic Issue 1": 4,
     "Comic Issue 2": 4,
     "Comic Issue 3": 4,
-    "Comic Issue 3": 4,
+    "Comic Issue 4": 4,
     // 2014 charity event item
     // https://www.pathofexile.com/forum/view-thread/919315
     "Angelic Mask": 5,
@@ -398,21 +398,21 @@ for (let element of elements) {
 
     let out = 0;
     let levenshtein_match = "";
-    let best_levenshtein_score = Infinity;
+    let best_levenshtein_distance = Infinity;
     for (let mtx in microtransactions) {
         for (let suffix of pack_suffixes) {
-            var current_levenshtein_score = levenshtein(transactionName, mtx + suffix)
+            var current_levenshtein_distance = levenshtein(transactionName, mtx + suffix)
             // lower levenshtein distance is better
-            if (current_levenshtein_score < best_levenshtein_score) {
+            if (current_levenshtein_distance < best_levenshtein_distance) {
                 out = microtransactions[mtx];
-                best_levenshtein_score = current_levenshtein_score;
+                best_levenshtein_distance = current_levenshtein_distance;
                 levenshtein_match = mtx + suffix;
             }
         }
     }
 
     // the mtx names must be identical, otherwise display an error
-    if (best_levenshtein_score >= 1) {
+    if (best_levenshtein_distance >= 1) {
         errormessage += "\n" + transactionName;
         out = 0;
     }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -3,6 +3,14 @@ var total = 0;
 var errormessage = "";
 
 var microtransactions = {
+    // Crucible
+    "Lithomancer": 30,
+    "Ancestral Lithomancer": 60,
+    "Ancient Lithomancer": 90,
+    "Enchanter": 30,
+    "Master Enchanter": 60,
+    "High Enchanter": 90,
+
     // 2023 Core
     "Tormentor": 60,
     "Hellfire": 100,
@@ -268,31 +276,30 @@ var microtransactions = {
 }
 
 for(var element of elements) {
-    tableEntry = element.innerHTML;
-    tableEntry = tableEntry.trim();
+    transactionName = element.innerHTML.trim();
 
     var out = 0;
 
     for(var mtx in microtransactions) {
         var value = microtransactions[mtx];
-        if (tableEntry.includes(mtx) && value > out){
+        if (transactionName.includes(mtx) && value > out){
             out = value;
         }
     }
 
     if(out === 0){
-        errormessage += "\n" + tableEntry;
+        errormessage += "\n" + transactionName;
     }
 
     var before = total;
     total += out;
     
-    console.log(tableEntry);
-    console.log(before + "+"+ out + "=" + total);
+    console.log(`${transactionName} (\$${out})`);
+    console.log(`${before} + ${out} = ${total}`);
 }
 
 if(errormessage == ""){
-    alert("You have spent " + "$" + total + " on microtransactions");
+    alert(`You have spent \$${total} on microtransactions`);
 }else{
     alert("You have spent " + "$" + total + " on microtransactions \n\n" + "Packs not found: "  + errormessage);
 }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -6,14 +6,20 @@ const microtransactions = {
     "Exilecon 2023 Ultra VIP": 2000,
     "Exilecon 2023 VIP": 700,
     "Exilecon 2023": 230,
+    // will never acually match
+    // because "Exilecon 2023" is more expensive
+    // TODO: implement Levenshtein distance?
     "Exilecon 2023 Balcony Ticket": 210,
 
     // Exilecon 2019
     "Exilecon Ultra VIP": 1000,
     "Exilecon VIP": 500,
     "Exilecon": 200,
+    // will never acually match
+    // because "Exilecon" is more expensive
+    // TODO: implement Levenshtein distance?
     "Exilecon Balcony Ticket": 180,
-    
+
     //Necropolis
     "Solar": 30,
     "Solar Knight": 60,
@@ -21,7 +27,7 @@ const microtransactions = {
     "Eldritch": 30,
     "Eldritch Hunger": 60,
     "Eldritch Horror": 90,
-    
+
     // 2024 Core
     "Kalguuran Runesmith": 60,
     "Shackled Immortal": 100,
@@ -102,7 +108,8 @@ const microtransactions = {
     // Expedition
     "Soulkeeper": 30,
     "Soulkeeper Vizier": 60,
-    "Soulkeepr Vizier": 60, //ggg have misspelled this in the account transactions list
+    // ggg has misspelled this in the account transactions list
+    "Soulkeepr Vizier": 60,
     "Soulkeeper Demigod": 90,
     "Aesir": 30,
     "Aesir Warrior": 60,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -272,33 +272,33 @@ const microtransactions = {
     "Highgate": 1100,
 
     // Forsaken Masters
-    "Apprentice": 50,
-    "Journeyman": 100,
-    "Master": 200,
-    "Grandmaster": 500,
+    "Apprentice Supporter Pack": 50,
+    "Journeyman Supporter Pack": 100,
+    "Master Supporter Pack": 200,
+    "Grandmaster Supporter Pack": 500,
 
     // Release
-    "Survivor": 50,
-    "Warrior": 120,
-    "Champion": 280,
-    "Conqueror": 900,
+    "Survivor Supporter Pack": 50,
+    "Warrior Supporter Pack": 120,
+    "Champion Supporter Pack": 280,
+    "Conqueror Supporter Pack": 900,
 
     // Open Beta
     "Open Beta": 30,
-    "Regal": 50,
-    "Divine": 110,
-    "Exalted": 270,
-    "Eternal": 1500,
+    "Regal Supporter Pack": 50,
+    "Divine Supporter Pack": 110,
+    "Exalted Supporter Pack": 270,
+    "Eternal Supporter Pack": 1500,
     "Ruler of Wraeclast": 12500,
 
     // Closed Beta
     "Early Access": 10,
     "Closed Beta": 15,
-    "Kiwi": 25,
-    "Bronze": 50,
-    "Silver": 100,
-    "Gold": 250,
-    "Diamond": 1000,
+    "Kiwi Supporter Pack": 25,
+    "Bronze Supporter Pack": 50,
+    "Silver Supporter Pack": 100,
+    "Gold Supporter Pack": 250,
+    "Diamond Supporter Pack": 1000,
 
     // Straight Points
     "50 Point": 5,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -4,9 +4,12 @@ const microtransactions = {
     "Paladin": 30,
     "Divine Paladin": 60,
     "Sacred Paladin": 90,
+    // the first packs with apostrophes
     "Penance": 30,
     "Acolyte's Penance": 60,
+    "Acolytes Penance": 60,
     "Zealot's Penance": 90,
+    "Zealots Penance": 90,
 
     // Exilecon 2023
     "Exilecon 2023 Ultra VIP": 2000,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,3 +1,5 @@
+// stolen from stackoverflow
+// https://stackoverflow.com/q/18516942
 var levenshtein = (function() {
     var row2 = [];
     return function(s1, s2) {
@@ -394,6 +396,15 @@ const microtransactions = {
 
 let total = 0;
 let errormessage = "";
+// the levenshtein distance finds incorrect matches if too many
+// letters are missing (if the pack suffix is missing or incorrect)
+// that is why we try suffixes in general
+// we try different suffixes because the suffix is not predictable
+let pack_suffixes = [
+    " Pack",
+    " Supporter Pack",
+    ""
+]
 
 for (let element of elements) {
     transactionName = element.innerHTML.trim();
@@ -402,20 +413,21 @@ for (let element of elements) {
     let levenshtein_match = "";
     let best_levenshtein_score = Infinity;
     for (let mtx in microtransactions) {
-        var current_levenshtein_score = levenshtein(transactionName, mtx)
-        if (current_levenshtein_score == best_levenshtein_score) {
-            console.log(`tied ${mtx} with score ${best_levenshtein_score}`)
-        }
+        for (let suffix of pack_suffixes) {
+            var current_levenshtein_score = levenshtein(transactionName, mtx + suffix)
         // lower levenshtein distance is better
         if (current_levenshtein_score < best_levenshtein_score) {
             out = microtransactions[mtx];
             best_levenshtein_score = current_levenshtein_score;
-            levenshtein_match = mtx;
+                levenshtein_match = mtx + suffix;
+            }
         }
     }
 
-    if (out === 0) {
+    // the mtx names must be identical, otherwise display an error
+    if (best_levenshtein_score >= 1) {
         errormessage += "\n" + transactionName;
+        out = 0;
     }
 
     let before = total;

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -136,6 +136,9 @@ const microtransactions = {
     "Faithsworn": 30,
     "Elite Faithsworn": 60,
 
+    // 2021 Endless Delve / Nexus -- https://www.pathofexile.com/forum/view-thread/3218435
+    "Cursed Supporter Pack": 60,
+
     // 2021 Core
     "Delve Core": 60,
     "Breach Core": 100,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -2,6 +2,21 @@ var elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
 var total = 0;
 var errormessage = "";
 var microtransactions = {
+    // 2024 Core
+    "Kalguuran Runesmith":60,
+    "Shackled Immortal":100,
+    "Vaal Serpent-God":1600,
+    "Karui Elemancer":2400,
+    "Sandwraith Assassin":480,
+
+    // Trial of the Ancestors
+    "Shade":30,
+    "Haunting Shade":60,
+    "Midnight Shade":90,
+    "Disciple":30,
+    "Ardent Disciple":60,
+    "Devoted Disciple":90,
+
     // Crucible
     "Lithomancer": 30,
     "Ancestral Lithomancer": 60,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -45,30 +45,11 @@ const microtransactions = {
     "Paladin": 30,
     "Divine Paladin": 60,
     "Sacred Paladin": 90,
-    // the first packs with apostrophes
     "Penance": 30,
     "Acolyte's Penance": 60,
     "Acolytes Penance": 60,
     "Zealot's Penance": 90,
     "Zealots Penance": 90,
-
-    // Exilecon 2023
-    "Exilecon 2023 Ultra VIP": 2000,
-    "Exilecon 2023 VIP": 700,
-    "Exilecon 2023": 230,
-    // will never acually match
-    // because "Exilecon 2023" is more expensive
-    // TODO: implement Levenshtein distance?
-    "Exilecon 2023 Balcony Ticket": 210,
-
-    // Exilecon 2019
-    "Exilecon Ultra VIP": 1000,
-    "Exilecon VIP": 500,
-    "Exilecon": 200,
-    // will never acually match
-    // because "Exilecon" is more expensive
-    // TODO: implement Levenshtein distance?
-    "Exilecon Balcony Ticket": 180,
 
     // Necropolis
     "Solar": 30,
@@ -92,6 +73,12 @@ const microtransactions = {
     "Disciple": 30,
     "Ardent Disciple": 60,
     "Devoted Disciple": 90,
+
+    // Exilecon 2023
+    "Exilecon 2023 Ultra VIP": 2000,
+    "Exilecon 2023 VIP": 700,
+    "Exilecon 2023": 230,
+    "Exilecon 2023 Balcony Ticket": 210,
 
     // Crucible
     "Lithomancer": 30,
@@ -158,7 +145,8 @@ const microtransactions = {
     // Expedition
     "Soulkeeper": 30,
     "Soulkeeper Vizier": 60,
-    // ggg has misspelled this in the account transactions list
+    // intentionally misspelled because ggg has
+    // misspelled this in the account transactions list
     "Soulkeepr Vizier": 60,
     "Soulkeeper Demigod": 90,
     "Aesir": 30,
@@ -214,6 +202,12 @@ const microtransactions = {
     "Grand Sanctum": 60,
     "Damnation": 30,
     "Eternal Damnation": 60,
+
+    // Exilecon 2019
+    "Exilecon Ultra VIP": 1000,
+    "Exilecon VIP": 500,
+    "Exilecon": 200,
+    "Exilecon Balcony Ticket": 180,
 
     // Blight
     "Sentinel": 30,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -317,9 +317,17 @@ const microtransactions = {
     // Vault Passes
     "Vault Pass": 30,
 
-    // Questionmark
+    // other MTX
+    //
+    // digital comic: Origins
+    // might be unreliable due to different price tiers
+    // https://www.pathofexile.com/forum/view-thread/1703254
     "Comic": 4,
+    // 2014 charity event item
+    // https://www.pathofexile.com/forum/view-thread/919315
     "Angelic Mask": 5,
+    // 2015 Australia Day event item
+    // https://www.pathofexile.com/forum/view-thread/1185814
     "Koala": 14,
     "Brazil": 40,
 }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -341,6 +341,7 @@ const microtransactions = {
     // Closed Beta
     "Early Access": 10,
     "Closed Beta": 15,
+    "Supporter Pack": 15,
     "Kiwi": 25,
     "Bronze": 50,
     "Silver": 100,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -136,9 +136,6 @@ const microtransactions = {
     "Faithsworn": 30,
     "Elite Faithsworn": 60,
 
-    // 2021 Endless Delve / Nexus -- https://www.pathofexile.com/forum/view-thread/3218435
-    "Cursed Supporter Pack": 60,
-
     // 2021 Core
     "Delve Core": 60,
     "Breach Core": 100,
@@ -351,6 +348,9 @@ const microtransactions = {
     // https://www.pathofexile.com/forum/view-thread/1185814
     "Koala": 14,
     "Brazil": 40,
+    // 2021 Endless Delve / Nexus
+    // https://www.pathofexile.com/forum/view-thread/3218435
+    "Cursed Supporter Pack": 60,
 }
 
 let total = 0;

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -281,23 +281,34 @@ const microtransactions = {
     "Highgate": 1100,
 
     // Forsaken Masters
+    "Apprentice Pack": 50,
     "Apprentice Supporter Pack": 50,
+    "Journeyman Pack": 100,
     "Journeyman Supporter Pack": 100,
+    "Master Pack": 200,
     "Master Supporter Pack": 200,
+    "Grandmaster Pack": 500,
     "Grandmaster Supporter Pack": 500,
 
     // Release
     "Survivor Supporter Pack": 50,
     "Survivor Pack": 50,
+    "Warrior Pack": 120,
     "Warrior Supporter Pack": 120,
+    "Champion Pack": 280,
     "Champion Supporter Pack": 280,
+    "Conqueror Pack": 900,
     "Conqueror Supporter Pack": 900,
 
     // Open Beta
     "Open Beta": 30,
+    "Regal Pack": 50,
     "Regal Supporter Pack": 50,
+    "Divine Pack": 110,
     "Divine Supporter Pack": 110,
+    "Exalted Pack": 270,
     "Exalted Supporter Pack": 270,
+    "Eternal Pack": 1500,
     "Eternal Supporter Pack": 1500,
     "Ruler of Wraeclast": 12500,
 
@@ -305,9 +316,13 @@ const microtransactions = {
     "Early Access": 10,
     "Closed Beta": 15,
     "Kiwi Pack": 25,
+    "Bronze Pack": 50,
     "Bronze Supporter Pack": 50,
+    "Silver Pack": 100,
     "Silver Supporter Pack": 100,
+    "Gold Pack": 250,
     "Gold Supporter Pack": 250,
+    "Diamond Pack": 1000,
     "Diamond Supporter Pack": 1000,
 
     // Straight Points

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -316,49 +316,33 @@ const microtransactions = {
     "Highgate": 1100,
 
     // Forsaken Masters
-    "Apprentice Pack": 50,
-    "Apprentice Supporter Pack": 50,
-    "Journeyman Pack": 100,
-    "Journeyman Supporter Pack": 100,
-    "Master Pack": 200,
-    "Master Supporter Pack": 200,
-    "Grandmaster Pack": 500,
-    "Grandmaster Supporter Pack": 500,
+    "Apprentice": 50,
+    "Journeyman": 100,
+    "Master": 200,
+    "Grandmaster": 500,
 
     // Release
-    "Survivor Supporter Pack": 50,
-    "Survivor Pack": 50,
-    "Warrior Pack": 120,
-    "Warrior Supporter Pack": 120,
-    "Champion Pack": 280,
-    "Champion Supporter Pack": 280,
-    "Conqueror Pack": 900,
-    "Conqueror Supporter Pack": 900,
+    "Survivor": 50,
+    "Warrior": 120,
+    "Champion": 280,
+    "Conqueror": 900,
 
     // Open Beta
     "Open Beta": 30,
-    "Regal Pack": 50,
-    "Regal Supporter Pack": 50,
-    "Divine Pack": 110,
-    "Divine Supporter Pack": 110,
-    "Exalted Pack": 270,
-    "Exalted Supporter Pack": 270,
-    "Eternal Pack": 1500,
-    "Eternal Supporter Pack": 1500,
+    "Regal": 50,
+    "Divine": 110,
+    "Exalted": 270,
+    "Eternal": 1500,
     "Ruler of Wraeclast": 12500,
 
     // Closed Beta
     "Early Access": 10,
     "Closed Beta": 15,
-    "Kiwi Pack": 25,
-    "Bronze Pack": 50,
-    "Bronze Supporter Pack": 50,
-    "Silver Pack": 100,
-    "Silver Supporter Pack": 100,
-    "Gold Pack": 250,
-    "Gold Supporter Pack": 250,
-    "Diamond Pack": 1000,
-    "Diamond Supporter Pack": 1000,
+    "Kiwi": 25,
+    "Bronze": 50,
+    "Silver": 100,
+    "Gold": 250,
+    "Diamond": 1000,
 
     // Straight Points
     "50 Point": 5,
@@ -368,14 +352,21 @@ const microtransactions = {
     "1065 Point": 100,
 
     // Vault Passes
-    "Vault Pass": 30,
+    // Season 1 & 2 Passes were sold with the same name
+    "Kirac's Vault Pass": 30,
+    "Kirac's Vault Pass (Kalandra)": 30,
+    "Kirac's Vault Pass (Sanctum)": 30,
+    // Season 5 and onwards are purchased using points
 
     // other MTX
     //
     // digital comic: Origins
-    // might be unreliable due to different price tiers
+    // unreliable due to different price tiers
     // https://www.pathofexile.com/forum/view-thread/1703254
-    "Comic": 4,
+    "Comic Issue 1": 4,
+    "Comic Issue 2": 4,
+    "Comic Issue 3": 4,
+    "Comic Issue 3": 4,
     // 2014 charity event item
     // https://www.pathofexile.com/forum/view-thread/919315
     "Angelic Mask": 5,
@@ -385,7 +376,7 @@ const microtransactions = {
     "Brazil": 40,
     // 2021 Endless Delve / Nexus
     // https://www.pathofexile.com/forum/view-thread/3218435
-    "Cursed Supporter Pack": 60,
+    "Cursed": 60,
 }
 
 let total = 0;
@@ -409,10 +400,10 @@ for (let element of elements) {
     for (let mtx in microtransactions) {
         for (let suffix of pack_suffixes) {
             var current_levenshtein_score = levenshtein(transactionName, mtx + suffix)
-        // lower levenshtein distance is better
-        if (current_levenshtein_score < best_levenshtein_score) {
-            out = microtransactions[mtx];
-            best_levenshtein_score = current_levenshtein_score;
+            // lower levenshtein distance is better
+            if (current_levenshtein_score < best_levenshtein_score) {
+                out = microtransactions[mtx];
+                best_levenshtein_score = current_levenshtein_score;
                 levenshtein_match = mtx + suffix;
             }
         }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -433,13 +433,13 @@ for (let element of elements) {
     let before = total;
     total += out;
 
-    console.log(`${transactionName} (\$${out}) matched with "${levenshtein_match}"`);
+    console.log(`${transactionName} (USD ${out}) matched "${levenshtein_match}"`);
     console.log(`${before} + ${out} = ${total}`);
 }
 
 if (errormessage == "") {
-    alert(`You have spent \$${total} on microtransactions`);
+    alert(`You have spent USD ${total} on microtransactions`);
 } else {
-    console.warn( "The following supporter packs are unaccounted for...", errormessage );
-    alert("You have spent " + "$" + total + " on microtransactions \n\n" + "Packs not found: " + errormessage);
+    console.warn("The following supporter packs are unaccounted for...", errormessage);
+    alert(`You have spent USD ${total} on microtransactions \n\nPacks not found: ${errormessage}`);
 }

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,3 +1,34 @@
+var levenshtein = (function() {
+    var row2 = [];
+    return function(s1, s2) {
+        if (s1 === s2) {
+            return 0;
+        } else {
+            var s1_len = s1.length, s2_len = s2.length;
+            if (s1_len && s2_len) {
+                var i1 = 0, i2 = 0, a, b, c, c2, row = row2;
+                while (i1 < s1_len)
+                    row[i1] = ++i1;
+                while (i2 < s2_len) {
+                    c2 = s2.charCodeAt(i2);
+                    a = i2;
+                    ++i2;
+                    b = i2;
+                    for (i1 = 0; i1 < s1_len; ++i1) {
+                        c = a + (s1.charCodeAt(i1) === c2 ? 0 : 1);
+                        a = row[i1];
+                        b = b < a ? (b < c ? b + 1 : c) : (a < c ? a + 1 : c);
+                        row[i1] = b;
+                    }
+                }
+                return b;
+            } else {
+                return s1_len + s2_len;
+            }
+        }
+    };
+})();
+
 const elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
 const microtransactions = {
     // PoE2 Early Access
@@ -368,11 +399,18 @@ for (let element of elements) {
     transactionName = element.innerHTML.trim();
 
     let out = 0;
-
+    let levenshtein_match = "";
+    let best_levenshtein_score = Infinity;
     for (let mtx in microtransactions) {
-        let value = microtransactions[mtx];
-        if (transactionName.includes(mtx) && value > out) {
-            out = value;
+        var current_levenshtein_score = levenshtein(transactionName, mtx)
+        if (current_levenshtein_score == best_levenshtein_score) {
+            console.log(`tied ${mtx} with score ${best_levenshtein_score}`)
+        }
+        // lower levenshtein distance is better
+        if (current_levenshtein_score < best_levenshtein_score) {
+            out = microtransactions[mtx];
+            best_levenshtein_score = current_levenshtein_score;
+            levenshtein_match = mtx;
         }
     }
 
@@ -383,7 +421,7 @@ for (let element of elements) {
     let before = total;
     total += out;
 
-    console.log(`${transactionName} (\$${out})`);
+    console.log(`${transactionName} (\$${out}) matched with "${levenshtein_match}"`);
     console.log(`${before} + ${out} = ${total}`);
 }
 

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,6 +1,12 @@
 const elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
-
 const microtransactions = {
+    // Settlers of Kalguur
+    "Paladin": 30,
+    "Divine Paladin": 60,
+    "Sacred Paladin": 90,
+    "Penance": 30,
+    "Acolyte's Penance": 60,
+    "Zealot's Penance": 90,
 
     // Exilecon 2023
     "Exilecon 2023 Ultra VIP": 2000,
@@ -20,7 +26,7 @@ const microtransactions = {
     // TODO: implement Levenshtein distance?
     "Exilecon Balcony Ticket": 180,
 
-    //Necropolis
+    // Necropolis
     "Solar": 30,
     "Solar Knight": 60,
     "Solar Guardian": 90,
@@ -35,7 +41,7 @@ const microtransactions = {
     "Karui Elemancer": 240,
     "Sandwraith Assassin": 480,
 
-    // Ancestors
+    // Trial of the Ancestors
     "Shade": 30,
     "Haunting Shade": 60,
     "Midnight Shade": 90,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,5 +1,13 @@
 const elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
 const microtransactions = {
+    // PoE2 Early Access
+    "Path of Exile 2 Early Access": 30,
+    "Lord of Ogham": 60,
+    "King of the Faridun": 100,
+    "Thaumaturge of the Vaal": 160,
+    "Warlord of the Karui": 240,
+    "Liberator of Wraeclast": 480,
+
     // Settlers of Kalguur
     "Paladin": 30,
     "Divine Paladin": 60,


### PR DESCRIPTION
The Script has some fundamental issues with how it correlates Supporter Packs as they appear on the PoE transaction Page with how we store their names.

1. The inconsistent naming scheme of Transactions causes difficulty for us maintainers since we are unable to know the exact name of every single Supporter Pack (see #1 #13 #15 #16 #18 #19 #24 #26 ). I want to highlight #11 .
2. When multiple Supporter Packs are matching to a Transaction, it prefers the more expensive one (this is usually desired, except for the `Vaal` Pack and some others)

To fix the first point I add different suffixes to every mtx in our list. This way confusions whether you need `... Pack` or `... Supporter Pack` are avoided. This also requires the next fix.

To fix the second point I have added a levenshtein distance calculation so that only the match with the most correct letters is used. This currently rejects matches if a single character is wrong. You might want to adjust the rejection threshold to a value you feel comfortable with.

This PR also orders most mtx in chronological order.